### PR TITLE
Update language server now that completion module is a separate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ serde_derive = "1.0.0"
 languageserver-types = "0.11.0"
 debugserver-types = "0.3.0"
 
-gluon = "0.5.0"
+gluon = { git = "https://github.com/gluon-lang/gluon" }
+gluon_completion = { git = "https://github.com/gluon-lang/gluon" }
 
 [dev-dependencies]
 pretty_assertions = "0.2.0"

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -562,7 +562,7 @@ impl Debugger {
                                     }
                                     Type::Variant(ref row) => {
                                         let type_field = row.row_iter()
-                                            .nth(data.tag as usize)
+                                            .nth(data.tag() as usize)
                                             .expect("Variant tag is out of bounds");
                                         data.fields
                                             .into_iter()


### PR DESCRIPTION
This PR updates the language server to use the new completion crate. The tests are currently failing, but I am submitting this as WIP. It should probably not be merged until a new version of gluon is released so that we can remove the git dependency.