### PR TITLE
Fix `format_expr()` path for gluon v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ serde_derive = "1.0.0"
 languageserver-types = "0.11.0"
 debugserver-types = "0.3.0"
 
-gluon = "0.5.0"
+gluon = "0.6.0"
+gluon_format = "0.6.0"
 
 [dev-dependencies]
 pretty_assertions = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate futures;
 extern crate log;
 extern crate env_logger;
 extern crate gluon;
+extern crate gluon_format;
 extern crate url;
 extern crate url_serde;
 
@@ -684,7 +685,7 @@ pub fn run() {
                 let thread = thread.clone();
                 let format = move |params: DocumentFormattingParams| -> BoxFuture<Vec<TextEdit>, _> {
                     retrieve_expr(&thread, &params.text_document.uri, |module| {
-                        use gluon::parser::format_expr;
+                        use gluon_format::format_expr;
                         let formatted = format_expr(&module.source_string)?;
                         Ok(vec![
                             TextEdit {


### PR DESCRIPTION
This PR fixes `format_expr()` function path from `gluon::parser::format_expr()` to `gluon_format::format_expr()`.
Corresponding to gluon-lang/gluon#352.

The tests don't pass in this branch alone.
Please rebase to other PRs (#10, #11?).